### PR TITLE
perf: Optimise reward simulator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,14 @@
-:ghost:
+:sloth:	
 
 ### Description
+What:
 
-Describe your PR
+How:
 
+References: 
 
-### References
+---
 
-
-### Risks
-* [ None / Low / Medium / High ]
+### Code Checklist
+- [ ] tested
+- [ ] documented

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     types:
       - opened
+      - edited
   push:
     branches:
       - main

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - synchronize
   push:
     branches:

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -6,6 +6,7 @@ on:
     types:
       - opened
       - edited
+      - synchronize
   push:
     branches:
       - main

--- a/poetry.lock
+++ b/poetry.lock
@@ -1006,4 +1006,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8c55840a093db2f2c6611ded16bf10bb1ac598408db37fd7076fc5865ca6eadd"
+content-hash = "e7f885f3ac424f62d62e4056a7a2096abf4adc431dfa845c2215c0c2473f7710"

--- a/poetry.lock
+++ b/poetry.lock
@@ -783,6 +783,68 @@ files = [
 ]
 
 [[package]]
+name = "pyinstrument"
+version = "4.5.0"
+description = "Call stack profiler for Python. Shows you why your code is slow!"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyinstrument-4.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b2f0a36c6edc1c1531f270aec9846b48304de19aea7fb819733d438a6fb4bf2e"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0d8122041f997274d64d0c78d183a4be2337a97bfb9fbec84c1ed8c9ba68265f"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94f061f3459cb9c509e57273ed6551e37d2d0c8cce0c327b1c8d5cbbc8fb9ddc"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f8ae4434c6b1552e36f32b19e7d3f9fc5c5dc246178adce049f027c4ebb28a98"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6b3071525ca0a7cea708d5ada359dad3561ed272dc58ec9027d46e1b3e11266"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:dcf4fd5c6e11d1ba42ec91ecaf97970c59c50bd07b4208f6cdbc1b16d635c130"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8543f2f1ed205e6578459b434ceeeba03ef841108d648b74b27e4e99c91fe439"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53c9ab55fbf73f30a71dae43a2cc6a8733b22e29007091eae65a9b468648597b"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-win32.whl", hash = "sha256:ac631d289f271e284052dad3b008a0abcb2a2da72c5de72eb8d56841d6942f15"},
+    {file = "pyinstrument-4.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:ec68f7d63c218e998aba55c40fc9cbd4132675ef1ae9b652dce58134e722c229"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e06159e0ecd013e352e4905b4342e71e71b630b77078503979679355a4a77c33"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0922ece1ef965215f912e7b4218cf24b385763ccbb2cbdbb41b2b35826410310"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83f9dd0d581e3b22ee47d1f076037b6ce0cd891fad1f09121ba8638436f1b760"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:af29ed2cd39d838473a81c9e40eccc7b8e1ab09acac743f54b80f62728fa4de3"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e15ede05892a2273ac062538f7d62136bcfedda0983d3554cf67c2d52a7c9dd9"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:385dfbfceee954e90febeed89f89570f27b0956f05cec5d206efa082efcf5acd"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eab6064f3abb9802449bf446a36502399c04714b6b81354fddc8bcae13f82376"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a53fb221e7a7f8658c2cc1afc242158cf721d4f68ba67189524ab0aae61cca12"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-win32.whl", hash = "sha256:f736cba0b250cc288571a4b1edf331194eefd36ca06c55ba987a2fcc30ead826"},
+    {file = "pyinstrument-4.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:976bc13f2dee5a0a0b065b7695329634496b25574467d0d76285994360186371"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58f538be679f55b9a2ce13e39d6c07c41683c23e37cac40d9a0789d6bc137d35"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bd24aeebcff18f5ef08961ece3c04bcffaba2ad55ffd243fd04c908b4a17674"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b33a63c5e291b2a2e073803ee6686f5be8536c84688969eeec67608ef76ebca1"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a9f4164c1534c04f07add30fd2e61f94ea0c68ae8bf082bd83655cb6c15a258"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ca1094ad94d155e709ab8622728ced9a7d19091d346dd18720d8e8ad83ccaf58"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:261356a7c47fa0d7da58349112e9e06761674a6dd99f08fc71ba672c01bf7f7c"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c948fd93c215042770c3d0d3d72746720dac26fed6e539020f5c7ad18be953ea"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-win32.whl", hash = "sha256:e1ff10704ec28646ec37f972981763a45a718215b6bd9ff4bc30bafd0887acbb"},
+    {file = "pyinstrument-4.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c880ea33fa5c2c5bbdfa6d896b7addf31bea8967e4d4c85ec921f7d052749e10"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ab0187c10fee5bf539bf9ba0ab4c081dac50a767a88c7f9e708c4fd0342e06aa"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2e98bf17f7d919dba2494fa6af3bc1704ba704a0adad37e80908a317371ee29d"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:876c915ac51ed4b69e8a6d6867f7bc8a02929b32dafb73e2c4ce4c8f06ac260c"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05690e3dfff1ffca38da15f6fdcc8231e7931e92abeb32f36f64785cfc1dca83"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20589781fb8245fc9a1654ae46eca8c900d32a14923c947ba32398f8afd8fd1c"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e31b9adf6914ad1f2fb0debd04d2968cd12770dfa7903c0cc7bfc88a7faca0d6"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:33039688c0fadf132e70273657e9a4e30c22b648d2f9732c4711ced8a441c650"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fc9e6a617847b4e3d7b59a1e6f252d326703e8719891fc52efee83f56f065c80"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-win32.whl", hash = "sha256:57febfcfc61d54c117edb432a939fe974eecd49e4da9711efaa927e61a548fdd"},
+    {file = "pyinstrument-4.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:488859b9ea05c36c99c48efcd02f7f781b1fa54b8d09a1f5eda96fdfb9e0356c"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:078bbbea6e626da73c38ec6692720a7f7b79a2e7fb6536861e26687f58f5f707"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:04e9b88131c1b4bd9917aab2dd4fd47468598cbf719448710f1a6d51bdc295d8"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63f1c1cf89536fc2084179c69fa65414fc018d1a3e48039f8cb6ff82b278ea28"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ca55eee67a7a93bd2c24625da312dddf5c4ae6fa5ba59ba0f908e1bf24a84bd"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1309b6211ac1ddce56cda9e870c42d9d08ba51930c9d07505179435869c4db16"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bc78253cd2a203812d70a7637b045a6d00b68c4035ad73edf0e03f6828c465f5"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0f122fd1f93a5db81a2acc05b56525b7c197a31e271fe2ae151d242ff599fcb8"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2a7d941df6d433662311cf6ad267b7782d30f78651ce34f3132539d5a7d65e0c"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-win32.whl", hash = "sha256:14e2c5f176babd747b4d2fb17c00de36fcbc91fa5e9a4152fb09cf9e19364f18"},
+    {file = "pyinstrument-4.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:c28e2f82aedf35686cf95c7d5366a65cf54ef92490307de1ab38efe7b727e997"},
+    {file = "pyinstrument-4.5.0.tar.gz", hash = "sha256:ce01c7304b76932761c2be3d998f08b1863fd409a3709851e48af6cc0dc10eb2"},
+]
+
+[package.extras]
+jupyter = ["ipython"]
+
+[[package]]
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -944,4 +1006,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7f05922f530255f830f928a6d5107c64207cfff5423a5cbfb381ca1306dcf24a"
+content-hash = "8c55840a093db2f2c6611ded16bf10bb1ac598408db37fd7076fc5865ca6eadd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.9"
 numpy = "^1.24.3"
 seaborn = "^0.12.2"
 matplotlib = "^3.7.1"
+pyinstrument = "^4.5.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ python = "^3.9"
 numpy = "^1.24.3"
 seaborn = "^0.12.2"
 matplotlib = "^3.7.1"
-pyinstrument = "^4.5.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.3.0"
@@ -18,6 +17,7 @@ flake8 = "^6.0.0"
 black = "^23.3.0"
 pytest = "^7.3.1"
 pytest-cov = "^4.1.0"
+pyinstrument = "^4.5.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/chapter_2/ten_armed_bandits/action_reward_simulator.py
+++ b/src/chapter_2/ten_armed_bandits/action_reward_simulator.py
@@ -49,16 +49,16 @@ class NormalActionRewardSimulator(ActionRewardSimulator):
         return self._stateful_generator.standard_normal(size=self._num_actions)
 
     def generate_reward(self, action: int) -> float:
-        if len(self._cache.get(action)) == 0:
+        if len(self._cache[action]) == 0:
             del self.__dict__["_cache"]
-        return self._cache.get(action).pop()
+        return self._cache[action].pop()
 
 
 class PoissonActionRewardSimulator(ActionRewardSimulator):
     """Simulating action rewards from Poisson distributions."""
 
     @cached_property
-    def _cache(self):
+    def _cache(self) -> Dict[int, List]:
         return {
             action: list(self._stateful_generator.poisson(reward, size=50_000))
             for action, reward in enumerate(self._true_action_rewards)
@@ -68,9 +68,9 @@ class PoissonActionRewardSimulator(ActionRewardSimulator):
         return self._stateful_generator.poisson(3, size=self._num_actions)
 
     def generate_reward(self, action: int) -> float:
-        if len(self._cache.get(action)) == 0:
+        if len(self._cache[action]) == 0:
             del self.__dict__["_cache"]
-        return self._cache.get(action).pop()
+        return self._cache[action].pop()
 
 
 class RandomWalkRewardSimulator(ActionRewardSimulator):

--- a/src/chapter_2/ten_armed_bandits/action_reward_simulator.py
+++ b/src/chapter_2/ten_armed_bandits/action_reward_simulator.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from functools import cached_property
+from typing import Dict, List
 
 import numpy as np
 import numpy.typing as npt
@@ -38,7 +39,7 @@ class NormalActionRewardSimulator(ActionRewardSimulator):
     """Simulating action rewards from normal distributions."""
 
     @cached_property
-    def _cache(self):
+    def _cache(self) -> Dict[int, List]:
         return {
             action: list(self._stateful_generator.normal(reward, 1, size=50_000))
             for action, reward in enumerate(self._true_action_rewards)
@@ -47,7 +48,7 @@ class NormalActionRewardSimulator(ActionRewardSimulator):
     def _set_true_rewards(self) -> npt.NDArray:
         return self._stateful_generator.standard_normal(size=self._num_actions)
 
-    def generate_reward(self, action: int):
+    def generate_reward(self, action: int) -> float:
         if len(self._cache.get(action)) == 0:
             del self.__dict__["_cache"]
         return self._cache.get(action).pop()
@@ -56,17 +57,27 @@ class NormalActionRewardSimulator(ActionRewardSimulator):
 class PoissonActionRewardSimulator(ActionRewardSimulator):
     """Simulating action rewards from Poisson distributions."""
 
+    @cached_property
+    def _cache(self):
+        return {
+            action: list(self._stateful_generator.poisson(reward, size=50_000))
+            for action, reward in enumerate(self._true_action_rewards)
+        }
+
     def _set_true_rewards(self) -> npt.NDArray:
-        print("Execute once")
         return self._stateful_generator.poisson(3, size=self._num_actions)
 
     def generate_reward(self, action: int) -> float:
-        return self._stateful_generator.poisson(self._true_action_rewards[action], size=1).item()
+        if len(self._cache.get(action)) == 0:
+            del self.__dict__["_cache"]
+        return self._cache.get(action).pop()
 
 
 class RandomWalkRewardSimulator(ActionRewardSimulator):
     """Simulating action rewards from normal distributions, where each action reward samples from
-    a distribution with a mean value that follows a random walk."""
+    a distribution with a mean value that follows a random walk.
+    Note: running this simulator coudl be slow as it has not been optimised yet.
+    """
 
     def _set_true_rewards(self) -> npt.NDArray:
         return np.zeros(self._num_actions)

--- a/src/chapter_2/ten_armed_bandits/run.py
+++ b/src/chapter_2/ten_armed_bandits/run.py
@@ -1,7 +1,7 @@
 """Implement an epsilon greedy algorithm simulated for a 10 armed bandit problem with actions sampled from
 normal distributions."""
-
 import matplotlib.pyplot as plt
+from pyinstrument import Profiler
 
 from src.chapter_2.ten_armed_bandits.action_reward_simulator import NormalActionRewardSimulator
 from src.chapter_2.ten_armed_bandits.action_tracker import ActionTrackerPool
@@ -43,11 +43,15 @@ def main():
         )
         action_tracker_pool.plot_percentage_of_exploit(ax3, plot_label)
 
-    ax1.set_tile("Average Reward")
-    ax2.set_tile("% Optimal Action")
-    ax3.set_tile("% Exploit")
-    plt.show()
+    ax1.title.set_text("Average Reward")
+    ax2.title.set_text("% Optimal Action")
+    ax3.title.set_text("% Exploit")
+    # plt.show()
 
 
 if __name__ == "__main__":
+    profiler = Profiler()
+    profiler.start()
     main()
+    profiler.stop()
+    profiler.print()

--- a/src/chapter_2/ten_armed_bandits/run.py
+++ b/src/chapter_2/ten_armed_bandits/run.py
@@ -46,7 +46,7 @@ def main():
     ax1.title.set_text("Average Reward")
     ax2.title.set_text("% Optimal Action")
     ax3.title.set_text("% Exploit")
-    # plt.show()
+    plt.show()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
:ghost:

### Description

Optimise the reward simulator by replacing the call to the random generator with a caching mechanism. Instead of generating one number at a time, generate a large pool of random numbers and retrieve them from the pool as needed. This change has significant reduced the runtime from 541 seconds to 84 seconds.

Before optimising
<img width="612" alt="image" src="https://github.com/gabechu/introduction-reinforcement-learning/assets/42528401/57e4060d-b20e-4b72-9b69-e5da682237dd">

After optimising
<img width="569" alt="image" src="https://github.com/gabechu/introduction-reinforcement-learning/assets/42528401/ca406018-73b6-4b52-8e04-78d0df355ee8">


### References


### Risks
* [ None / Low / Medium / High ]
