### PR TITLE
feat: Switch between different initial action rewards

### DIFF
--- a/src/chapter_2/ten_armed_bandits/greedy_agent.py
+++ b/src/chapter_2/ten_armed_bandits/greedy_agent.py
@@ -11,12 +11,13 @@ def run_epsilon_greedy_agent(
     action_reward_simulator: ActionRewardSimulator,
     action_tracker: ActionTracker,
     reward_tracker: RewardTracker,
+    initial_action_rewards: npt.NDArray,
     steps: int,
     epsilon: float,
 ) -> npt.NDArray[np.float64]:
     """Estimate rewards for a epsilon greedy agent."""
 
-    estimated_action_rewards = np.zeros(shape=action_tracker.num_actions)
+    estimated_action_rewards = initial_action_rewards
     for _ in range(steps):
         # an agent navigates using greedy strategy
         action = choose_action_with_greedy_epsilon(estimated_action_rewards, epsilon)

--- a/src/chapter_2/ten_armed_bandits/greedy_agent.py
+++ b/src/chapter_2/ten_armed_bandits/greedy_agent.py
@@ -17,7 +17,7 @@ def run_epsilon_greedy_agent(
 ) -> npt.NDArray[np.float64]:
     """Estimate rewards for a epsilon greedy agent."""
 
-    estimated_action_rewards = initial_action_rewards
+    estimated_action_rewards = initial_action_rewards.copy()
     for _ in range(steps):
         # an agent navigates using greedy strategy
         action = choose_action_with_greedy_epsilon(estimated_action_rewards, epsilon)

--- a/src/chapter_2/ten_armed_bandits/greedy_agent.py
+++ b/src/chapter_2/ten_armed_bandits/greedy_agent.py
@@ -28,7 +28,7 @@ def run_epsilon_greedy_agent(
         updated_mean_reward = weighted_incremental_average_update(
             old_average=estimated_action_rewards[action],
             new_value=current_reward,
-            weight=1 / action_tracker.get_action_count(action),
+            weight=0.8,
         )
 
         estimated_action_rewards[action] = updated_mean_reward

--- a/src/chapter_2/ten_armed_bandits/reward_tracker.py
+++ b/src/chapter_2/ten_armed_bandits/reward_tracker.py
@@ -8,12 +8,12 @@ class RewardTracker(object):
     """
 
     def __init__(self):
-        self._rewards = []
+        self.rewards = []
         self.mean_rewards = []
 
     def add_current_reward(self, reward: float):
         """Add the current reward to reward list."""
-        self._rewards.append(reward)
+        self.rewards.append(reward)
 
     def add_mean_reward(self, reward: float):
         """Add the mean reward for the action being taken."""
@@ -24,15 +24,15 @@ class RewardTrackerPool(object):
     """A pool of reward trackers."""
 
     def __init__(self, num_bandits: int) -> None:
-        self._trackers = [RewardTracker() for _ in range(num_bandits)]
+        self.trackers = [RewardTracker() for _ in range(num_bandits)]
 
     def get_reward_tracker(self, bandit: int) -> RewardTracker:
         """Fetch a reward tracker for the specific bandit problem."""
-        return self._trackers[bandit]
+        return self.trackers[bandit]
 
     def calcualte_mean_of_mean_rewards(self) -> npt.NDArray:
         """Calculate mean rewards for each step across different runs of bandits."""
-        all_mean_rewards = np.array([tracker.mean_rewards for tracker in self._trackers])
+        all_mean_rewards = np.array([tracker.mean_rewards for tracker in self.trackers])
         return all_mean_rewards.mean(axis=0)
 
     def plot_mean_of_mean_rewards(self, ax, label: str):

--- a/src/chapter_2/ten_armed_bandits/run.py
+++ b/src/chapter_2/ten_armed_bandits/run.py
@@ -1,6 +1,7 @@
 """Implement an epsilon greedy algorithm simulated for a 10 armed bandit problem with actions sampled from
 normal distributions."""
 import matplotlib.pyplot as plt
+import numpy as np
 from pyinstrument import Profiler
 
 from src.chapter_2.ten_armed_bandits.action_reward_simulator import NormalActionRewardSimulator
@@ -17,6 +18,7 @@ def main():
     steps_per_bandit = 1000
     epsilons = [0.0, 0.01, 0.1]
     action_reward_simulator = NormalActionRewardSimulator(num_actions, seed=None)
+    initial_action_rewards = np.zeros(num_actions)
     _, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(15, 15))
 
     # run program
@@ -31,6 +33,7 @@ def main():
                 action_reward_simulator=action_reward_simulator,
                 action_tracker=action_tracker,
                 reward_tracker=reward_tracker,
+                initial_action_rewards=initial_action_rewards,
                 steps=steps_per_bandit,
                 epsilon=epsilon,
             )

--- a/src/chapter_2/ten_armed_bandits/run.py
+++ b/src/chapter_2/ten_armed_bandits/run.py
@@ -16,9 +16,9 @@ def main():
     num_actions = 10
     num_bandits = 2000
     steps_per_bandit = 1000
-    epsilons = [0.0, 0.01, 0.1]
+    epsilons = [0.0]
     action_reward_simulator = NormalActionRewardSimulator(num_actions, seed=None)
-    initial_action_rewards = np.zeros(shape=num_actions)
+    initial_action_rewards = np.full(shape=num_actions, fill_value=5)
     _, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(15, 15))
 
     # run program

--- a/src/chapter_2/ten_armed_bandits/run.py
+++ b/src/chapter_2/ten_armed_bandits/run.py
@@ -18,7 +18,7 @@ def main():
     steps_per_bandit = 1000
     epsilons = [0.0, 0.01, 0.1]
     action_reward_simulator = NormalActionRewardSimulator(num_actions, seed=None)
-    initial_action_rewards = np.zeros(num_actions)
+    initial_action_rewards = np.zeros(shape=num_actions)
     _, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(15, 15))
 
     # run program

--- a/tests/unit/chapter_2/ten_armed_bandits/test_reward_tracker.py
+++ b/tests/unit/chapter_2/ten_armed_bandits/test_reward_tracker.py
@@ -10,15 +10,13 @@ class TestRewardTracker(unittest.TestCase):
     def test_add_one_reward(self):
         instance = RewardTracker()
         instance.add_current_reward(0.0)
-        actual = instance._rewards
-        assert actual == [0.0]
+        assert instance.rewards == [0.0]
 
     def test_add_two_rewards(self):
         instance = RewardTracker()
         instance.add_current_reward(1)
         instance.add_current_reward(2)
-        actual = instance._rewards
-        assert actual == [1, 2]
+        assert instance.rewards == [1, 2]
 
     def test_add_one_mean_reward(self):
         instance = RewardTracker()
@@ -30,15 +28,14 @@ class TestRewardTracker(unittest.TestCase):
         instance = RewardTracker()
         instance.add_mean_reward(0.0)
         instance.add_mean_reward(1.0)
-        actual = instance.mean_rewards
-        assert actual == [0.0, 1.0]
+        assert instance.mean_rewards == [0.0, 1.0]
 
 
 class TestRewardTrackerPool(unittest.TestCase):
     def test_initialised_action_tracker_pool_size(self):
         size = 10
         instance = RewardTrackerPool(num_bandits=size)
-        actual = len(instance._trackers)
+        actual = len(instance.trackers)
         assert actual == size
 
     def test_get_reward_tracker(self):
@@ -48,12 +45,22 @@ class TestRewardTrackerPool(unittest.TestCase):
         assert isinstance(instance.get_reward_tracker(2), RewardTracker)
 
     def test_calcualte_mean_of_mean_rewards(self):
-        isinstance = RewardTrackerPool(num_bandits=3)
-        mock_trackers = [RewardTracker(), RewardTracker(), RewardTracker()]
-        mock_trackers[0].mean_rewards = [1, 2, 1, 2]
-        mock_trackers[1].mean_rewards = [3, 4, 3, 4]
-        mock_trackers[2].mean_rewards = [5, 6, 5, 6]
-        isinstance._trackers = mock_trackers
+        instance = RewardTrackerPool(num_bandits=3)
+        # mean rewards [1, 2, 1, 2]
+        instance.trackers[0].add_mean_reward(1)
+        instance.trackers[0].add_mean_reward(2)
+        instance.trackers[0].add_mean_reward(1)
+        instance.trackers[0].add_mean_reward(2)
+        # mean rewards [3, 4, 3, 4]
+        instance.trackers[1].add_mean_reward(3)
+        instance.trackers[1].add_mean_reward(4)
+        instance.trackers[1].add_mean_reward(3)
+        instance.trackers[1].add_mean_reward(4)
+        # mean rewards [5, 6, 5, 6]
+        instance.trackers[2].add_mean_reward(5)
+        instance.trackers[2].add_mean_reward(6)
+        instance.trackers[2].add_mean_reward(5)
+        instance.trackers[2].add_mean_reward(6)
 
-        actual = isinstance.calcualte_mean_of_mean_rewards()
+        actual = instance.calcualte_mean_of_mean_rewards()
         assert_array_equal(actual, np.array([3.0, 4.0, 3.0, 4.0]))

--- a/tests/unit/chapter_2/ten_armed_bandits/test_utils.py
+++ b/tests/unit/chapter_2/ten_armed_bandits/test_utils.py
@@ -16,7 +16,7 @@ def test_weighted_incremental_average_update_with_weight_greater_than_one():
     assert actual == 9
 
 
-def test_weighted_incremental_average_update_for_simple_average():
+def test_weighted_incremental_average_update_for_sample_average():
     actual = []
     targets = [1, 2, 3, 4, 5]
     avg = 0

--- a/tests/unit/chapter_2/ten_armed_bandits/test_utils.py
+++ b/tests/unit/chapter_2/ten_armed_bandits/test_utils.py
@@ -1,11 +1,28 @@
 from src.chapter_2.ten_armed_bandits.utils import weighted_incremental_average_update
 
 
-def test__incremental_average_update_for_one_step():
-    actual = weighted_incremental_average_update(old_average=0, new_value=5, weight=1)
+def test_weighted_incremental_average_update_with_weight_of_one():
+    actual = weighted_incremental_average_update(old_average=1, new_value=5, weight=1)
     assert actual == 5
 
 
-def test__incremental_average_update_for_two_steps():
-    actual = weighted_incremental_average_update(old_average=1, new_value=3, weight=0.5)
-    assert actual == 2
+def test_weighted_incremental_average_update_with_weight_less_than_one():
+    actual = weighted_incremental_average_update(old_average=1, new_value=5, weight=0.5)
+    assert actual == 3
+
+
+def test_weighted_incremental_average_update_with_weight_greater_than_one():
+    actual = weighted_incremental_average_update(old_average=1, new_value=5, weight=2)
+    assert actual == 9
+
+
+def test_weighted_incremental_average_update_for_simple_average():
+    actual = []
+    targets = [1, 2, 3, 4, 5]
+    avg = 0
+    for i, value in enumerate(targets):
+        new_avg = weighted_incremental_average_update(old_average=avg, new_value=value, weight=1 / (i + 1))
+        actual.append(new_avg)
+        avg = new_avg
+
+    assert actual == [1.0, 1.5, 2.0, 2.5, 3.0]


### PR DESCRIPTION
:sloth:	

### Description
What:
Enable user to use custom initial weights for bandit problems.

How:
Instead of hardcoding the weights within a bandit problem, modify the bandit problem function to accept weights as an argument. This allows users to pass different values for the weights as needed.

References: 

---

### Code Checklist
- [x] tested
- [x] documented
